### PR TITLE
chore: Update abandoned url in example.qmd

### DIFF
--- a/pages/example.qmd
+++ b/pages/example.qmd
@@ -14,7 +14,7 @@ Values are color-coded to reflect the piece of sequencing metadata they correspo
 
 -   **Strain names**. Also labelled *isolate* in GenBank or *virus name* in GISAID. These values may be full/complete or partial. As an example, the strain name for a sequence in GenBank is `WA-CDC-LAB-12345`. A lab might submit a full strain name via ELR (`WA-CDC-LAB-12345`), *or* they might submit a partial string (`12345`) which must be combined with lab-specific logic to create the final, full strain name.
 
--   [**Pango**](https://www.pango.network/){target="_blank"} **lineages**
+-   [**Pango**](https://cov-lineages.org/){target="_blank"} **lineages**
 
 -   **Clinical accessions**. This is the value used to link a sequencing result to a specific specimen and/or lab test. This is usually submitted as the filler order number. However, a variety of factors can influence where these data might be in ELR submissions, such as which lab is submitting the sequencing results to WA DOH and whether the same or different labs conducted the diagnostic and sequencing tests.
 


### PR DESCRIPTION
URL used to direct to website hosting info about pango lineage assignments for covid19 but seems to have been abandoned and the URL now redirects to sites flagged by WaTech for phishing activity